### PR TITLE
feat(ui): Navbar, Card, Footer components (responsive, typed, Tailwind)

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import Link from 'next/link'
+
+type Tone = 'default' | 'success' | 'warning' | 'danger'
+
+export interface CardProps {
+  title: string
+  description?: string
+  price?: string | number
+  imageSrc: string
+  imageAlt?: string
+  badge?: { label: string; tone?: Tone }
+  meta?: string
+  colorsCount?: number
+  href?: string
+  className?: string
+}
+
+function badgeClasses(tone: Tone = 'default') {
+  if (tone === 'success') return 'bg-[color:var(--color-green)]/10 text-[color:var(--color-green)]'
+  if (tone === 'warning') return 'bg-[color:var(--color-orange)]/10 text-[color:var(--color-orange)]'
+  if (tone === 'danger') return 'bg-[color:var(--color-red)]/10 text-[color:var(--color-red)]'
+  return 'bg-[color:var(--color-light-200)] text-[color:var(--color-dark-900)]'
+}
+
+export default function Card({
+  title,
+  description,
+  price,
+  imageSrc,
+  imageAlt = '',
+  badge,
+  meta,
+  colorsCount,
+  href,
+  className = '',
+}: CardProps) {
+  const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) =>
+    href ? (
+      <Link href={href} aria-label={title} className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--color-dark-900)]">
+        {children}
+      </Link>
+    ) : (
+      <>{children}</>
+    )
+
+  return (
+    <div
+      className={`group overflow-hidden rounded-2xl border border-[color:var(--color-light-300)] bg-[color:var(--color-light-100)] shadow-sm transition hover:shadow-md ${className}`}
+    >
+      <Wrapper>
+        <div className="relative">
+          <img
+            src={imageSrc}
+            alt={imageAlt}
+            className="h-auto w-full object-cover aspect-[4/3] md:aspect-[16/9] bg-[color:var(--color-light-200)]"
+            loading="lazy"
+          />
+          {badge ? (
+            <span
+              className={`absolute left-3 top-3 rounded-full px-3 py-1 text-[length:var(--text-footnote)] leading-[var(--text-footnote--line-height)] font-[var(--text-footnote--font-weight)] ${badgeClasses(badge.tone)}`}
+            >
+              {badge.label}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="space-y-2 p-4 sm:p-5">
+          <h3 className="text-[length:var(--text-heading-3)] leading-[var(--text-heading-3--line-height)] font-[var(--text-heading-3--font-weight)] text-[color:var(--color-dark-900)]">
+            {title}
+          </h3>
+          {description ? (
+            <p className="text-[length:var(--text-body)] leading-[var(--text-body--line-height)] font-[var(--text-body--font-weight)] text-[color:var(--color-dark-700)]">
+              {description}
+            </p>
+          ) : null}
+          <div className="flex items-center justify-between pt-2">
+            <div className="flex flex-col">
+              {meta ? (
+                <span className="text-[length:var(--text-caption)] leading-[var(--text-caption--line-height)] font-[var(--text-caption--font-weight)] text-[color:var(--color-dark-700)]">
+                  {meta}
+                </span>
+              ) : null}
+              {typeof colorsCount === 'number' ? (
+                <span className="text-[length:var(--text-footnote)] leading-[var(--text-footnote--line-height)] font-[var(--text-footnote--font-weight)] text-[color:var(--color-dark-500)]">
+                  {colorsCount} Colour
+                </span>
+              ) : null}
+            </div>
+            {price !== undefined ? (
+              <span className="text-[length:var(--text-lead)] leading-[var(--text-lead--line-height)] font-[var(--text-lead--font-weight)] text-[color:var(--color-dark-900)]">
+                {typeof price === 'number' ? `$${price.toFixed(2)}` : price}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </Wrapper>
+    </div>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import Link from 'next/link'
+
+export interface FooterLink {
+  label: string
+  href: string
+}
+
+export interface FooterSection {
+  heading: string
+  links: FooterLink[]
+}
+
+export interface FooterProps {
+  sections?: FooterSection[]
+  logoAlt?: string
+  socials?: { kind: 'x' | 'facebook' | 'instagram'; href: string }[]
+  copyrightName?: string
+  className?: string
+}
+
+const defaultSections: FooterSection[] = [
+  {
+    heading: 'Featured',
+    links: [
+      { label: 'Air Force 1', href: '#' },
+      { label: 'Huarache', href: '#' },
+      { label: 'Air Max 90', href: '#' },
+      { label: 'Air Max 95', href: '#' },
+    ],
+  },
+  {
+    heading: 'Shoes',
+    links: [
+      { label: 'All Shoes', href: '#' },
+      { label: 'Custom Shoes', href: '#' },
+      { label: 'Jordan Shoes', href: '#' },
+      { label: 'Running Shoes', href: '#' },
+    ],
+  },
+  {
+    heading: 'Clothing',
+    links: [
+      { label: 'All Clothing', href: '#' },
+      { label: 'Modest Wear', href: '#' },
+      { label: 'Hoodies & Pullovers', href: '#' },
+      { label: 'Shirts & Tops', href: '#' },
+    ],
+  },
+  {
+    heading: "Kids'",
+    links: [
+      { label: 'Infant & Toddler Shoes', href: '#' },
+      { label: "Kids' Shoes", href: '#' },
+      { label: "Kids' Jordan Shoes", href: '#' },
+      { label: "Kids' Basketball Shoes", href: '#' },
+    ],
+  },
+]
+
+const defaultSocials: FooterProps['socials'] = [
+  { kind: 'x', href: '#' },
+  { kind: 'facebook', href: '#' },
+  { kind: 'instagram', href: '#' },
+]
+
+function SocialIcon({ kind }: { kind: NonNullable<FooterProps['socials']>[number]['kind'] }) {
+  const src =
+    kind === 'x' ? '/x.svg' : kind === 'facebook' ? '/facebook.svg' : '/instagram.svg'
+  const label = kind === 'x' ? 'X' : kind[0].toUpperCase() + kind.slice(1)
+  return (
+    <img
+      src={src}
+      width={24}
+      height={24}
+      alt={label}
+      className="h-6 w-6"
+    />
+  )
+}
+
+export default function Footer({
+  sections = defaultSections,
+  logoAlt = 'Logo',
+  socials = defaultSocials,
+  copyrightName = 'Nike, Inc.',
+  className = '',
+}: FooterProps) {
+  const year = new Date().getFullYear()
+  return (
+    <footer
+      aria-label="Footer"
+      className={`mt-16 bg-[color:var(--color-dark-900)] text-[color:var(--color-light-100)] ${className}`}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-5">
+          <div className="flex items-start">
+            <img src="/logo.svg" alt={logoAlt} width={36} height={36} />
+          </div>
+
+          {sections.map((section) => (
+            <div key={section.heading}>
+              <h4 className="mb-4 text-[length:var(--text-heading-3)] leading-[var(--text-heading-3--line-height)] font-[var(--text-heading-3--font-weight)]">
+                {section.heading}
+              </h4>
+              <ul className="space-y-3">
+                {section.links.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      className="text-[color:var(--color-dark-500)] hover:text-[color:var(--color-light-100)] text-[length:var(--text-body)] leading-[var(--text-body--line-height)] font-[var(--text-body--font-weight)] transition-colors"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          <div className="flex items-start justify-start md:justify-end gap-4">
+            {socials?.map((s) => (
+              <Link
+                key={s.kind}
+                href={s.href}
+                aria-label={s.kind}
+                className="grid h-10 w-10 place-items-center rounded-full bg-[color:var(--color-light-100)] text-[color:var(--color-dark-900)] hover:opacity-90 transition"
+              >
+                <SocialIcon kind={s.kind} />
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-10 border-t border-white/10 pt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-[length:var(--text-footnote)] leading-[var(--text-footnote--line-height)] font-[var(--text-footnote--font-weight)] text-[color:var(--color-dark-500)]">
+            © {year} {copyrightName} All Rights Reserved
+          </p>
+          <div className="flex flex-wrap gap-x-6 gap-y-2">
+            {['Guides', 'Terms of Sale', 'Terms of Use', 'Nike Privacy Policy'].map((label) => (
+              <Link
+                key={label}
+                href="#"
+                className="text-[length:var(--text-footnote)] leading-[var(--text-footnote--line-height)] font-[var(--text-footnote--font-weight)] text-[color:var(--color-dark-500)] hover:text-[color:var(--color-light-100)]"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react'
+import Link from 'next/link'
+
+export interface NavLink {
+  label: string
+  href: string
+}
+
+export interface NavbarProps {
+  links?: NavLink[]
+  logoAlt?: string
+  cta?: { label: string; href: string } | null
+  className?: string
+}
+
+const defaultLinks: NavLink[] = [
+  { label: 'Home', href: '#' },
+  { label: 'Men', href: '#' },
+  { label: 'Women', href: '#' },
+  { label: 'Kids', href: '#' },
+  { label: 'Sale', href: '#' },
+]
+
+export default function Navbar({
+  links = defaultLinks,
+  logoAlt = 'Logo',
+  cta = { label: 'Shop Now', href: '#' },
+  className = '',
+}: NavbarProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Primary"
+      className={`sticky top-0 z-40 w-full bg-[color:var(--color-light-100)]/90 backdrop-blur border-b border-[color:var(--color-light-300)] ${className}`}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="#" aria-label="Home" className="flex items-center">
+              <img src="/logo.svg" width={32} height={32} alt={logoAlt} />
+            </Link>
+            <span className="hidden sm:inline-block text-[length:var(--text-heading-3)] leading-[var(--text-heading-3--line-height)] font-[var(--text-heading-3--font-weight)] text-[color:var(--color-dark-900)]">
+              Nike Store
+            </span>
+          </div>
+
+          <div className="hidden md:flex items-center gap-8">
+            <ul className="flex items-center gap-6">
+              {links.map((l) => (
+                <li key={l.label}>
+                  <Link
+                    href={l.href}
+                    className="text-[color:var(--color-dark-700)] hover:text-[color:var(--color-dark-900)] text-[length:var(--text-body)] leading-[var(--text-body--line-height)] font-[var(--text-body--font-weight)] transition-colors"
+                  >
+                    {l.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+            {cta ? (
+              <Link
+                href={cta.href}
+                className="rounded-full bg-[color:var(--color-dark-900)] text-[color:var(--color-light-100)] px-4 py-2 text-[length:var(--text-caption)] leading-[var(--text-caption--line-height)] font-[var(--text-caption--font-weight)] hover:opacity-90 transition"
+              >
+                {cta.label}
+              </Link>
+            ) : null}
+          </div>
+
+          <div className="md:hidden">
+            <button
+              type="button"
+              aria-controls="mobile-menu"
+              aria-expanded={open}
+              onClick={() => setOpen((v) => !v)}
+              className="inline-flex items-center justify-center rounded-md p-2 text-[color:var(--color-dark-900)] hover:bg-[color:var(--color-light-200)] focus:outline-none focus:ring-2 focus:ring-[color:var(--color-dark-900)]"
+            >
+              <span className="sr-only">Open main menu</span>
+              <svg
+                className={`h-6 w-6 ${open ? 'hidden' : 'block'}`}
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+              <svg
+                className={`h-6 w-6 ${open ? 'block' : 'hidden'}`}
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        id="mobile-menu"
+        className={`md:hidden overflow-hidden transition-all duration-300 ${open ? 'max-h-96' : 'max-h-0'}`}
+      >
+        <div className="space-y-1 px-4 pb-4">
+          {links.map((l) => (
+            <Link
+              key={l.label}
+              href={l.href}
+              className="block rounded-md px-3 py-2 text-[color:var(--color-dark-700)] hover:text-[color:var(--color-dark-900)] hover:bg-[color:var(--color-light-200)] text-[length:var(--text-body)] leading-[var(--text-body--line-height)] font-[var(--text-body--font-weight)]"
+              onClick={() => setOpen(false)}
+            >
+              {l.label}
+            </Link>
+          ))}
+          {cta ? (
+            <Link
+              href={cta.href}
+              className="mt-2 inline-flex rounded-full bg-[color:var(--color-dark-900)] text-[color:var(--color-light-100)] px-4 py-2 text-[length:var(--text-caption)] leading-[var(--text-caption--line-height)] font-[var(--text-caption--font-weight)]"
+              onClick={() => setOpen(false)}
+            >
+              {cta.label}
+            </Link>
+          ) : null}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,3 @@
+export { default as Navbar } from './Navbar'
+export { default as Card } from './Card'
+export { default as Footer } from './Footer'


### PR DESCRIPTION
# feat(ui): Navbar, Card, Footer components (responsive, typed, Tailwind)

## Summary
Adds three foundational UI components for the Nike web store:

- **Navbar**: Responsive navigation with logo, links, CTA button, and mobile hamburger menu
- **Card**: Reusable product card with image, title, description, price, badges, and optional linking
- **Footer**: Site footer with logo, link sections, social icons, and copyright

All components are fully typed with TypeScript, use Tailwind CSS with theme tokens from `globals.css`, and follow mobile-first responsive design principles. Components accept props for customization while providing sensible defaults.

## Review & Testing Checklist for Human
- [ ] **Visual testing**: Import components into a page and test responsive behavior on mobile/tablet/desktop breakpoints
- [ ] **CSS variables syntax**: Verify that `bg-[color:var(--color-dark-900)]` syntax works correctly with the defined theme tokens
- [ ] **Mobile hamburger menu**: Test the navbar toggle functionality and smooth transitions on mobile devices
- [ ] **Asset dependencies**: Confirm that `/logo.svg`, `/x.svg`, `/facebook.svg`, `/instagram.svg` exist in the public folder
- [ ] **Accessibility**: Test keyboard navigation and screen reader compatibility (especially hamburger menu controls)

### Test Plan
1. Temporarily import components into `src/app/page.tsx`
2. Add sample data (e.g., product images from `/public/shoes/` folder)
3. Test mobile hamburger menu toggle and navigation
4. Verify responsive layout at different screen sizes
5. Check that all theme colors and typography render correctly

### Notes
- All links use `href="#"` placeholders as requested (no routing logic implemented)
- Components use `<img>` tags which trigger Next.js warnings - consider migrating to `next/image` for production
- CSS variable syntax is non-standard Tailwind but should work with the custom theme tokens

**Link to Devin run**: https://app.devin.ai/sessions/3edcda58bf2c40ad95e9820de63695c9  
**Requested by**: Edgar Robles (@ed-robles)